### PR TITLE
feat: Initial Layout Setting

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-54d0af47'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.ggdl22m26f8"
+    "revision": "0.lghl778sgeo"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>letter bin</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,9 +8,6 @@ import MakeTrashcan from './pages/MakeTrashcan';
 import KakaoRedirect from './pages/KakaoRedirect';
 import GoogleOAuthPage from './pages/GoogleOAuthPage';
 import Home from './pages/Home';
-import { ThemeProvider } from 'styled-components';
-import { theme } from './styles/theme';
-
 
 function App() {
   return (

--- a/src/components/Spacer.jsx
+++ b/src/components/Spacer.jsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+const Spacer = styled.div`
+    height: ${({ size }) => size || '1rem'}; 
+    width: ${({ width }) => width || '100%'};
+`;
+
+export default Spacer;

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 @font-face {
-    font-family: 'HSSantokki-Regular';
-    src: url('./assets/fonts/HSSantokki-Regular.ttf') format('truetype');
-    font-weight: normal;
-    font-style: normal;
-  }
+  font-family: 'HSSantokki-Regular';
+  src: url('./assets/fonts/HSSantokki-Regular.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,13 +4,17 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 import GlobalStyle from './styles/GlobalStyles';
+import { ThemeProvider } from 'styled-components';
+import { theme } from './styles/theme'
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <BrowserRouter>
-    <React.StrictMode>
-      <GlobalStyle />
-      <App />
-    </React.StrictMode>
-  </BrowserRouter>
+  <ThemeProvider theme={theme}>
+    <GlobalStyle />
+    <BrowserRouter>
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>
+    </BrowserRouter>
+  </ThemeProvider>
 );

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import GoogleLoginButton from '../components/GoogleLoginButton';
+import Spacer from '../components/Spacer';
+import { SIZES } from '../styles/spacing';
 
 //카카오로그인 버튼을 통해 바로 로그인 할 수 있도록.
 const K_REST_API_KEY = import.meta.env.VITE_APP_K_REST_API_KEY;
@@ -32,12 +34,21 @@ const MainPage = () => {
     }
     return (
         <Container>
-            <Logo />
-            <Title>내쓰통</Title>
+            <LogoContainer>
+                <Spacer size={SIZES.XLARGE} />
+                <Logo />
+                <Spacer size={SIZES.MINIMUN} />
+                <Title>내쓰통</Title>
+            </LogoContainer>
+            <Spacer size={SIZES.LARGE} />
             <Buttons>
                 <Button onClick={kakaoLoginHandler}>카카오 로그인</Button>
+                <Spacer size={SIZES.MINIMUN} />
                 <GoogleLoginButton onClick={googleLoginHandler}>구글 로그인</GoogleLoginButton>
+                <Spacer size={SIZES.MINIMUN} />
                 <Button onClick={googleLoginHandlerServer}>구글 로그인(서버)</Button>
+                <Spacer size={SIZES.MINIMUN} />
+                <Text>쓸데 없는 편지 쓰러 가 보아요</Text>
             </Buttons>
         </Container>
     );
@@ -57,24 +68,49 @@ const Container = styled.div`
     background-image: url('src/assets/images/login-background.png');
 `
 
+const LogoContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: ${({ theme }) => theme.InnerSection}; 
+    ${({ theme }) => theme.fixedInner};
+`
+
 const Logo = styled.img.attrs({
     src: 'src/assets/images/logo.png',
     alt: 'Logo'
 })`
-    width: ${({ theme }) => theme.InnerSection}; 
+    width: 100%;
 `;
 
 const Title = styled.div`
-`
+    display: flex;
+    font-family: 'HSSantokki-Regular';
+    font-size: calc(${({ theme }) => theme.InnerSection} * 0.4); 
+    ${({ theme }) => theme.fixedFontSize};
+    width: 100%;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+`;
+
 
 const Buttons = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-`
+    width: ${({ theme }) => theme.MiddleSection};
+    ${({ theme }) => theme.fixedMiddle};
+    
+`;
 
 const Button = styled.button`
     padding: 0.5rem;
-    width: ${({ theme }) => theme.MiddleSection};
+    width: 100%;
+`
+
+const Text = styled.div`
+
 `

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -1,76 +1,11 @@
-//GlobalStyle.js
 import { createGlobalStyle } from 'styled-components';
 
 export const GlobalStyle = createGlobalStyle`
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
+
+html, body {
+  font-family: sans-serif;
   margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
 }
-/* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
-footer, header, hgroup, menu, nav, section {
-  display: block;
-}
-body {
-  line-height: 1;
-}
-ol, ul {
-  list-style: none;
-}
-blockquote, q {
-  quotes: none;
-}
-blockquote:before, blockquote:after,
-q:before, q:after {
-  content: '';
-  content: none;
-}
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
-}
-
-// box-sizing 적용
-* {
-  box-sizing: border-box;
-}
-
-a {
-  text-decoration: none;
-  color: inherit;
-}
-
-
 
 `;
 

--- a/src/styles/spacing.js
+++ b/src/styles/spacing.js
@@ -1,0 +1,8 @@
+export const SIZES = {
+  MINIMUN: '0.5rem',
+  SMALL: '1rem',
+  MEDIUM: '2rem',
+  LARGE: '3rem',
+  MLARGE: '8rem',
+  XLARGE: '12rem',
+};

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,5 +1,31 @@
+import { css } from 'styled-components';
+
 export const theme = {
   InnerSection: '24vw',
   MiddleSection: '48vw',
   OuterSection: '96vw',
+
+  fixedInner: css`
+    @media (min-width: 600px) {
+      width: 120px;
+    }
+  `,
+
+  fixedMiddle: css`
+    @media (min-width: 600px) {
+      width: 240px;
+    }
+  `,
+
+  fixedOuter: css`
+    @media (min-width: 600px) {
+      width: 480px;
+    }
+  `,
+
+  fixedFontSize: css`
+    @media (min-width: 600px) {
+      font-size: 3rem;
+    }
+  `,
 };


### PR DESCRIPTION
시작화면 레이아웃 설정
- 로고, 폰트 적용(Global CSS와 index.css 간의 덮어쓰는 이슈 해결)
- 세로 컴포넌트 사이 간격 추가하는 Spacer 컴포넌트 추가. 사이즈는 rem 단위
- 로고 타이틀 폰트 길이가 자꾸 로고 사이즈 가로길이랑 안 맞는 이슈가 있어서 로고 컨테이너로 로고와 타이틀을 감싸고 상위 vw를 기준으로 font-size가 설정되게 수정함
- vw 수정: 레이아웃을 vw로 지정하니 600px 넘어가는 웹 사이즈에서 컴포넌트 사이즈가 변경되는 이슈 발생 -> theme.js 에서 고정된 내부, 중간, 외부 컴포넌트 길이를 미디어쿼리로 지정해서 600px 넘어가도 변경되지 않게 수정.